### PR TITLE
parametrisation of cadvisor housekeeping_interval.

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,0 +1,3 @@
+cadvisor:
+  housekeeping_interval: 5s
+

--- a/roles/cadvisor/tasks/main.yml
+++ b/roles/cadvisor/tasks/main.yml
@@ -3,7 +3,7 @@
   docker:
     detach: True
     image: "google/cadvisor:v0.23.2"
-    command: "-storage_driver_db=cadvisor -storage_driver_host={{ influx_ip }}:8086 -storage_driver=influxdb" 
+    command: "-storage_driver_db=cadvisor -storage_driver_host={{ influx_ip }}:8086 -storage_driver=influxdb --housekeeping_interval={{ cadvisor.housekeeping_interval }}" 
     name: "cadvisor"
     ports: 
       # don't bind to the host port 8080 since swift is using it by default


### PR DESCRIPTION
default value can be found in group_vars/all.yml
customization is possible through the reservation.yaml file since
it is passed as a file containing variables during the first ansible run.
