### PR TITLE
Improve role distribution

### DIFF
--- a/01_deploy_nodes.py
+++ b/01_deploy_nodes.py
@@ -42,7 +42,7 @@ class KollaG5k(G5kEngine):
 
         # Generate the inventory file
         vars = {
-            'all_nodes'                  : self.nodes,
+            'all_nodes'                  : self.deployed_nodes,
             # TODO: Handle the case of 0/many util.
             'util_node'                  : roles['util'][0],
             'control_nodes'              : roles['controller'],
@@ -59,11 +59,11 @@ class KollaG5k(G5kEngine):
         logger.info("Inventory file written to " + style.emph(inventory_path))
 
         # TODO workarround
-        self.exec_command_on_nodes(self.nodes, 'apt-get update && apt-get -y --force-yes install apt-transport-https',
+        self.exec_command_on_nodes(self.deployed_nodes, 'apt-get update && apt-get -y --force-yes install apt-transport-https',
             'Workarround: installing apt-transport-https...')
 
         # Install python on the nodes
-        self.exec_command_on_nodes(self.nodes, 'apt-get -y install python',
+        self.exec_command_on_nodes(self.deployed_nodes, 'apt-get -y install python',
             'Installing Python on all the nodes...')
 
         # Run the Ansible playbooks

--- a/test.py
+++ b/test.py
@@ -1,0 +1,83 @@
+import unittest
+from engine.g5k_engine import G5kEngine, check_nodes, ROLE_DISTRIBUTION_MODE_STRICT
+from execo.host import Host
+
+class TestBuildRoles(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = G5kEngine()
+        self.engine.config = {
+            "resources": {
+                "a": {
+                    "controller": 1,
+                    "compute" : 2,
+                    "network" : 1,
+                    "storage" : 1,
+                    "util"    : 1
+                }
+            }
+        }
+
+    def test_not_enough_nodes(self):
+        self.engine.deployed_nodes = map(lambda x: Host(x), ["a-1", "a-2", "a-3", "a-4"])
+        with self.assertRaises(Exception):
+            roles = self.engine.build_roles()
+        
+    def test_build_roles_same_number_of_nodes(self):
+        self.engine.deployed_nodes = map(lambda x: Host(x), ["a-1", "a-2", "a-3", "a-4", "a-5", "a-6"])
+        roles = self.engine.build_roles()
+        self.assertEquals(1, len(roles["controller"]))
+        self.assertEquals(1, len(roles["storage"]))
+        self.assertEquals(2, len(roles["compute"]))
+        self.assertEquals(1, len(roles["network"]))
+        self.assertEquals(1, len(roles["util"]))
+
+    def test_build_roles_less_deployed_nodes(self):
+        self.engine.deployed_nodes = map(lambda x: Host(x), ["a-1", "a-2", "a-3", "a-4", "a-5"])
+        roles = self.engine.build_roles()
+        self.assertEquals(1, len(roles["controller"]))
+        self.assertEquals(1, len(roles["storage"]))
+        self.assertEquals(1, len(roles["compute"]))
+        self.assertEquals(1, len(roles["network"]))
+        self.assertEquals(1, len(roles["util"]))
+
+class TestCheckNodes(unittest.TestCase):
+
+    def setUp(self):
+        self.roles = {
+                "a": {
+                    "controller": 1,
+                    "compute" : 1,
+                    "network" : 1,
+                    "storage" : 1,
+                    "util"    : 1
+                },
+                "b": {
+                    "compute": 2
+                }
+            }
+
+    def test_enough_nodes_strict(self):
+        nodes = [1, 2, 3, 4, 5, 6, 7]
+        self.assertTrue(check_nodes(nodes, self.roles, ROLE_DISTRIBUTION_MODE_STRICT))
+
+    def test_enough_nodes_not_strict(self):
+        nodes = [1, 2, 3, 4, 5, 6, 7]
+        self.assertTrue(check_nodes(nodes, self.roles, ""))
+
+    def test_not_enough_nodes_strict(self):
+        nodes = [1, 2, 3, 4, 5, 6]
+        with self.assertRaises(Exception):
+            check_nodes(nodes, self.roles, ROLE_DISTRIBUTION_MODE_STRICT)
+
+    def test_not_enough_nodes_not_strict(self):
+        nodes = [1, 2, 3, 4, 5]
+        self.assertTrue(check_nodes(nodes, self.roles, ""))
+
+
+            
+            
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
It often happen that some nodes aren't deployed correctly.
When it happens it's maybe better to not use them in the subsequent
operations (ssh connections).
So roles are distributed from the deployed node.
When using a single cluster we garantee that
- each role has at least one node (allowing OS to run)
- one node belongs to at most one role

NB: With this choice it can happen that some roles doesn't have all the
desired nodes (in our case, some compute nodes may be missing).
