### PR TITLE
Copy logs before taring them.

### DIFF
--- a/ansible/roles/bench/tasks/logs.yml
+++ b/ansible/roles/bench/tasks/logs.yml
@@ -3,8 +3,12 @@
   stat: path=/var/lib/docker/volumes/kolla_logs/_data
   register: logs
 
+- name: Copying logs to /tmp
+  command: cp -r /var/lib/docker/volumes/kolla_logs/_data /tmp/kolla-logs
+  when: logs.stat.exists and logs.stat.isdir
+
 - name: Making a tar of the log files
-  command: tar -czf /kolla-logs.tar.gz /var/lib/docker/volumes/kolla_logs/_data/
+  command: tar -czf /kolla-logs.tar.gz /tmp/kolla-logs
   when: logs.stat.exists and logs.stat.isdir
 
 - name: Pull back kolla logs


### PR DESCRIPTION
Log files are continuously appened and tar may complaint about this.
To prevent this behaviour we copy the logs before taring them.

M
