### PR TITLE
Add elasticsearch/kibana.

### DIFF
--- a/results/README.md
+++ b/results/README.md
@@ -1,0 +1,42 @@
+# Post-Mortem analysis
+
+## What's inside the VMs ?
+
+Each virtual machine (VM) offer a toolbox to analyse various datas from the experimentation made with kolla-g5k. The datas themselves are also located inside the VM during the creation of the VM.
+
+You'll find :
+
+* Nginx exposed on port 8000. It allows you to browse Rally reports, confs and logs.
+* Grafana exposed on port 3000. It gives access of all the metrics collected during the experimentation
+* Kibana exposed on port 5601. It let you explores the logs.
+
+
+## List of provided experimentation
+
+* idle : *todo wiki url*
+* load-ded : *todo wiki url*
+* load-default : *todo wiki url*
+* concurrency : *todo wiki url*
+
+## Accessing the results
+
+Start a specific virtual machine :
+
+```
+vagrant up <experimentation>
+```
+
+Shutdown the virtual machine
+```
+vagrant halt <experimentation>
+```
+
+## Creating new results
+
+*todo*
+
+## Known limitation
+
+* The current implementation is tight to Grid'5000.
+* When creating a new set of result, indexing all the logs in elasticsearch will take some time.
+* From time to time VMs root filesystem goes read-only. Manually fsck the root partition and reboot may solve the issue `fsck /dev/vg0/lv_root`.

--- a/results/Vagrantfile
+++ b/results/Vagrantfile
@@ -3,6 +3,11 @@
 # vi: set ft=ruby :
 
 
+# This Vagrantfile makes use of the plugin vagrant-g5k
+# https://github.com/msimonin/vagrant-g5k
+#
+# version 0.0.13
+
 # The list of experimentation. There will be one VM per
 # experimentation. You can access it thought eg, `vagrant ssh idle`.
 XPS =[
@@ -37,8 +42,8 @@ Vagrant.configure(2) do |config|
     # user to log with inside the vm
     config.ssh.username = "root"
     # password to use to log inside the vm
-    config.ssh.password = ""
-
+    config.ssh.private_key_path = File.join(ENV['HOME'], ".ssh/id_rsa_discovery")
+ 
     config.vm.provider "g5k" do |g5k|
       # The project id.
       # It is used to generate uniq remote storage for images
@@ -53,14 +58,15 @@ Vagrant.configure(2) do |config|
 
       # site to use
       g5k.site = "rennes"
+      g5k.gateway = "access.grid5000.fr"
 
       # walltime to use
-      g5k.walltime = "02:00:00"
+      g5k.walltime = "03:00:00"
 
       # image location
-      #g5k.image = {
-      #  "path" => "/grid5000/virt-images/alpine_docker.qcow2",
-      #  "backing" => "cow"
+      # g5k.image = {
+      #  "path" => "$HOME/public/ubuntu1404.qcow2",
+      #  "backing" => "copy"
       #}
 
       # it could be backed by the ceph
@@ -73,7 +79,7 @@ Vagrant.configure(2) do |config|
       }
 
       # ports to expose (at least ssh has to be forwarded)
-      g5k.ports = ['2222-:22','3000-:3000', '8000-:80']
+      g5k.ports = ['2222-:22','3000-:3000', '8000-:80', '5601-:5601']
     end
 
     XPS.each do |xp|
@@ -106,7 +112,7 @@ Vagrant.configure(2) do |config|
         my.vm.provision :ansible do |ansible|
           ansible.playbook = "boilerplate.yml"
           ansible.extra_vars = xps
-          #ansible.verbose = "-vvvv"
+#          ansible.verbose = "-vvvv"
         end
       end
     end

--- a/results/ansible.cfg
+++ b/results/ansible.cfg
@@ -1,0 +1,2 @@
+[ssh_connection]
+pipelining=True

--- a/results/boilerplate.yml
+++ b/results/boilerplate.yml
@@ -30,6 +30,9 @@
     shell: "for i in $(ls /results/{{ item }}/*.tar.gz); do tar -C /results/{{ item }} -xzf $i; done"
     with_items: "{{ xps }}"
 
+  - name: Fixing permissions
+    command: chmod 755 -R /results
+
   - name: Starting influx container
     docker:
       name: "influx_{{ item.1 }}"
@@ -86,7 +89,7 @@
       # https://github.com/ansible/ansible-modules-core/issues/265
       # by adding an empty space at the beginning of the json ...
       body: " { \"name\": \"cadvisor-{{ item.1 }}\", \"type\": \"influxdb\", \"url\": \"http://172.17.0.1:{{ 18086 + item.0 * 100 }}\", \"access\": \"proxy\", \"database\": \"cadvisor\", \"user\": \"root\", \"password\": \"root\", \"isDefault\": true }"
-      status: 200,500
+      status_code: 200,500
     with_indexed_items: "{{ xps }}"
 
   - name: Add the influx collectd data source
@@ -103,7 +106,7 @@
       # by adding an empty space at the beginning of the json ...
       body: " { \"name\": \"collectd-{{ item.1 }}\", \"type\": \"influxdb\", \"url\": \"http://172.17.0.1:{{ 18086 + item.0 * 100 }}\", \"access\": \"proxy\", \"database\": \"collectd\", \"user\": \"root\", \"password\": \"root\", \"isDefault\": true }"
       return_content: yes
-      status: 200
+      status_code: 200
     with_indexed_items: "{{ xps }}"
 
   - name: Coping the nginx configuration file
@@ -121,8 +124,114 @@
       image: "nginx:alpine"
       name: "nginx"
       ports: "80:80"
-      state: started
       restart_policy: always
       volumes:
         - "/results:/usr/share/nginx/html"
         - "/nginx.conf:/etc/nginx/nginx.conf"
+      state: started
+
+  - name: Add elasticsearch
+    docker: 
+      detach: yes
+      image: elasticsearch
+      name: elasticsearch
+      ports: 
+        - "9200:9200"
+        - "9300:9300"
+
+  - name: Waiting for elasticsearch to become available
+    wait_for: 
+      # we use the bridge interface of docker
+      # instead of localhost
+      # api is accessible on loopback too quickly and isn't ready
+      host: "172.17.0.1"
+      port: 9200
+      state: started
+      delay: 2
+      timeout: 120
+
+ 
+  # We use the Type field to differentiate different xps 
+  # Do not analyse it will ease the analyse through kibana
+  #
+  - name: Check if heka index exists
+    uri : 
+      url: "http://localhost:9200/heka"
+      method: GET
+      body_format: json
+      status_code: 200,404
+    register: index
+
+  - debug: var=index
+
+  - name: Deleting old index
+    uri : 
+      url: "http://localhost:9200/heka"
+      method: DELETE
+      body_format: json
+    when: index.status == 200
+
+  - name: Create the heka index in elasticsearch
+    uri : 
+      url: "http://localhost:9200/heka"
+      method: PUT
+
+  # Ansible 1.9.x doesn't seem to be able to load a json 
+  # and use it in the body of the request properly
+  # e.g with ansible 2:
+  # body: "{{ lookup('file', 'files/mapping.json') | from_json | to_json}}"
+  # body_format: json
+  - name: Do not analyse some fields in elasticsearch (see mapping.json)
+    uri : 
+      url: "http://localhost:9200/heka/_mapping/message"
+      method: PUT
+      body: " { \"properties\": {\"{{ item }}\": {\"type\":\"string\", \"index\": \"not_analyzed\"}}}"
+      body_format: json
+    with_items: ["Type", "request_id", "tenant_id", "user_id", "programname"]
+
+  - name: Add kibana
+    docker: 
+      detach: yes
+      image: kibana
+      name: kibana
+      links: 
+        - "elasticsearch:elasticsearch"
+      ports:
+        - "5601:5601"
+
+  - name: Create heka configuration directory
+    file: path=/etc/heka state=directory
+
+  - name: Copying heka config files
+    copy: src=files/heka/ dest=/etc/heka/{{ item }}
+    with_items: "{{ xps }}"
+
+  - name: Generating heka specific configuration
+    template: src=templates/heka-{{ item[0] }}.toml.j2 dest=/etc/heka/{{ item[1] }}/heka-{{ item[0] }}.toml
+    with_nested: 
+      - ["elasticsearch", "openstack", "keystone", "mariadb", "rabbitmq"]
+      - "{{ xps }}"
+
+  - name: Add kolla/heka
+    docker: 
+      command: kolla_start
+      detach: yes
+      image: kolla/centos-binary-heka:2.0.2
+      name: "heka-{{ item }}"
+      links: 
+        - "elasticsearch:elasticsearch"
+      volumes:
+        - "/etc/heka/{{ item }}:/var/lib/kolla/config_files"
+        - "/etc/localtime:/etc/localtime:ro"
+        - "/results/{{ item }}/tmp/kolla-logs/_data:/var/log/kolla"
+        - "heka-{{ item }}:/var/cache/hekad"
+        - "heka_socket-{{ item }}:/var/lib/kolla/heka"
+        # patch to support custom types 
+        - "/etc/heka/{{ item }}/lua_decoders/os_openstack_log.lua:/usr/share/heka/lua_decoders/os_openstack_log.lua"
+        - "/etc/heka/{{ item }}/lua_decoders/os_keystone_apache_log.lua:/usr/share/heka/lua_decoders/os_keystone_apache_log.lua"
+        - "/etc/heka/{{ item }}/lua_decoders/os_mysql_log.lua:/usr/share/heka/lua_decoders/os_mysql_log.lua"
+        - "/etc/heka/{{ item }}/lua_decoders/os_rabbitmq_log.lua:/usr/share/heka/lua_decoders/os_rabbitmq_log.lua"
+      env:
+        SKIP_LOG_SETUP: true
+        KOLLA_CONFIG_STRATEGY: COPY_ALWAYS
+    with_items: "{{ xps }}"

--- a/results/files/heka/config.json
+++ b/results/files/heka/config.json
@@ -1,0 +1,40 @@
+{
+    "command": "/usr/bin/hekad -config=/etc/heka/",
+    "config_files": [
+        {
+            "source": "/var/lib/kolla/config_files/heka-elasticsearch.toml",
+            "dest": "/etc/heka/heka-elasticsearch.toml",
+            "owner": "heka",
+            "perm": "0600",
+            "optional": true
+        },
+        {
+            "source": "/var/lib/kolla/config_files/heka-openstack.toml",
+            "dest": "/etc/heka/heka-openstack.toml",
+            "owner": "heka",
+            "perm": "0600",
+            "optional": true
+        },
+        {
+            "source": "/var/lib/kolla/config_files/heka-keystone.toml",
+            "dest": "/etc/heka/heka-keystone.toml",
+            "owner": "heka",
+            "perm": "0600",
+            "optional": true
+        },
+        {
+            "source": "/var/lib/kolla/config_files/heka-mariadb.toml",
+            "dest": "/etc/heka/heka-mariadb.toml",
+            "owner": "heka",
+            "perm": "0600",
+            "optional": true
+        },
+        {
+            "source": "/var/lib/kolla/config_files/heka-rabbitmq.toml",
+            "dest": "/etc/heka/heka-rabbitmq.toml",
+            "owner": "heka",
+            "perm": "0600",
+            "optional": true
+        }
+    ]
+}

--- a/results/files/heka/lua_decoders/os_keystone_apache_log.lua
+++ b/results/files/heka/lua_decoders/os_keystone_apache_log.lua
@@ -1,0 +1,78 @@
+-- Copyright 2015 Mirantis, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local l      = require 'lpeg'
+l.locale(l)
+
+local common_log_format = require 'common_log_format'
+local patt = require 'os_patterns'
+local utils  = require 'os_utils'
+
+-- Allow custom type
+t = read_config('type')
+if t == nil or t == '' then
+  t = 'log'
+end
+
+local msg = {
+    Timestamp   = nil,
+    Type        = t,
+    Hostname    = nil,
+    Payload     = nil,
+    Pid         = nil,
+    Fields      = nil,
+    Severity    = 6,
+}
+
+local severity_label = utils.severity_to_label_map[msg.Severity]
+
+local apache_log_pattern = read_config("apache_log_pattern") or error(
+    "apache_log_pattern configuration must be specificed")
+local apache_grammar = common_log_format.build_apache_grammar(apache_log_pattern)
+local request_grammar = l.Ct(patt.http_request)
+
+function process_message ()
+
+    -- logger is either "keystone-apache-public" or "keystone-apache-admin"
+    local logger = read_message("Logger")
+
+    local log = read_message("Payload")
+
+    local m
+
+    m = apache_grammar:match(log)
+    if m then
+        msg.Logger = 'openstack.keystone'
+        msg.Payload = log
+        msg.Timestamp = m.time
+
+        msg.Fields = {}
+        msg.Fields.http_status = m.status
+        msg.Fields.http_response_time = m.request_time.value / 1e6 -- us to sec
+        msg.Fields.programname = logger
+        msg.Fields.severity_label = severity_label
+
+        local request = m.request
+        m = request_grammar:match(request)
+        if m then
+            msg.Fields.http_method = m.http_method
+            msg.Fields.http_url = m.http_url
+            msg.Fields.http_version = m.http_version
+        end
+
+        return utils.safe_inject_message(msg)
+    end
+
+    return -1, string.format("Failed to parse %s log: %s", logger, string.sub(log, 1, 64))
+end

--- a/results/files/heka/lua_decoders/os_mysql_log.lua
+++ b/results/files/heka/lua_decoders/os_mysql_log.lua
@@ -1,0 +1,56 @@
+-- Copyright 2015-2016 Mirantis, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+require "string"
+local l      = require 'lpeg'
+l.locale(l)
+
+local patt   = require 'os_patterns'
+local utils  = require 'os_utils'
+
+-- Allow custom type
+t = read_config('type')
+if t == nil or t == '' then
+  t = 'log'
+end
+
+local msg = {
+    Timestamp   = nil,
+    Type        = t,
+    Hostname    = nil,
+    Payload     = nil,
+    Pid         = nil,
+    Fields      = {},
+    Severity    = nil,
+}
+
+local sp    = patt.sp
+local colon = patt.colon
+
+-- mysqld logs are cranky,the date is YYMMMDD, the hours have no leading zero and the "real" severity level is enclosed by square brackets...
+local mysql_grammar = l.Ct(l.digit^-6 * sp^1 *  l.digit^-2 * colon * l.digit^-2 * colon * l.digit^-2 * sp^1 * l.P"[" * l.Cg(l.R("az", "AZ")^0 / string.upper, "SeverityLabel") * l.P"]" * sp^1 * l.Cg(patt.Message, "Message"))
+
+
+function process_message ()
+    local log = read_message("Payload")
+    local logger = read_message("Logger")
+
+    local m = mysql_grammar:match(log)
+    if not m then return -1 end
+
+    msg.Logger = logger
+    msg.Payload = m.Message
+    msg.Fields.severity_label = m.SeverityLabel
+
+    return utils.safe_inject_message(msg)
+end

--- a/results/files/heka/lua_decoders/os_openstack_log.lua
+++ b/results/files/heka/lua_decoders/os_openstack_log.lua
@@ -1,0 +1,146 @@
+-- Copyright 2015-2016 Mirantis, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+require "string"
+require "table"
+local l      = require 'lpeg'
+l.locale(l)
+
+local patt = require 'os_patterns'
+local utils = require 'os_utils'
+
+-- Allow custom type
+t = read_config('type')
+if t == nil or t == '' then
+  t = 'log'
+end
+
+local msg = {
+    Timestamp   = nil,
+    Type        = t,
+    Hostname    = nil,
+    Payload     = nil,
+    Pid         = nil,
+    Fields      = nil,
+    Severity    = nil,
+}
+
+-- traceback_lines is a reference to a table used to accumulate lines of
+-- a Traceback. traceback_key represent the key of the Traceback lines
+-- being accumulated in traceback_lines. This is used to know when to
+-- stop accumulating and inject the Heka message.
+local traceback_key = nil
+local traceback_lines = nil
+
+function prepare_message (service, timestamp, pid, severity_label,
+        python_module, programname, payload)
+    msg.Logger = 'openstack.' .. service
+    msg.Timestamp = timestamp
+    msg.Payload = payload
+    msg.Pid = pid
+    msg.Severity = utils.label_to_severity_map[severity_label] or 7
+    msg.Fields = {}
+    msg.Fields.severity_label = severity_label
+    msg.Fields.python_module = python_module
+    msg.Fields.programname = programname
+    msg.Payload = payload
+end
+
+-- OpenStack log messages are of this form:
+-- 2015-11-30 08:38:59.306 3434 INFO oslo_service.periodic_task [-] Blabla...
+--
+-- [-] is the "request" part, it can take multiple forms.
+
+function process_message ()
+
+    -- Logger is of form "<service>_<program>" (e.g. "nova_nova-api",
+    -- "neutron_l3-agent").
+    local logger = read_message("Logger")
+    local service, program = string.match(logger, '([^_]+)_(.+)')
+
+    local log = read_message("Payload")
+    local m
+
+    m = patt.openstack:match(log)
+    if not m then
+        return -1, string.format("Failed to parse %s log: %s", logger, string.sub(log, 1, 64))
+    end
+
+    local key = {
+        Timestamp     = m.Timestamp,
+        Pid           = m.Pid,
+        SeverityLabel = m.SeverityLabel,
+        PythonModule  = m.PythonModule,
+        service       = service,
+        program       = program,
+    }
+
+    if traceback_key ~= nil then
+        -- If traceback_key is not nil then it means we've started accumulated
+        -- lines of a Python traceback. We keep accumulating the traceback
+        -- lines util we get a different log key.
+        if utils.table_equal(traceback_key, key) then
+            table.insert(traceback_lines, m.Message)
+            return 0
+        else
+            prepare_message(traceback_key.service, traceback_key.Timestamp,
+                traceback_key.Pid, traceback_key.SeverityLabel,
+                traceback_key.PythonModule, traceback_key.program,
+                table.concat(traceback_lines, ''))
+            traceback_key = nil
+            traceback_lines = nil
+            -- Ignore safe_inject_message status code here to still get a
+            -- chance to inject the current log message.
+            utils.safe_inject_message(msg)
+        end
+    end
+
+    if patt.traceback:match(m.Message) then
+        -- Python traceback detected, begin accumulating the lines making
+        -- up the traceback.
+        traceback_key = key
+        traceback_lines = {}
+        table.insert(traceback_lines, m.Message)
+        return 0
+    end
+
+    prepare_message(service, m.Timestamp, m.Pid, m.SeverityLabel, m.PythonModule,
+        program, m.Message)
+
+    m = patt.openstack_request_context:match(msg.Payload)
+    if m then
+        msg.Fields.request_id = m.RequestId
+        if m.UserId then
+          msg.Fields.user_id = m.UserId
+        end
+        if m.TenantId then
+          msg.Fields.tenant_id = m.TenantId
+        end
+    end
+
+    m = patt.openstack_http:match(msg.Payload)
+    if m then
+        msg.Fields.http_method = m.http_method
+        msg.Fields.http_status = m.http_status
+        msg.Fields.http_url = m.http_url
+        msg.Fields.http_version = m.http_version
+        msg.Fields.http_response_size = m.http_response_size
+        msg.Fields.http_response_time = m.http_response_time
+        m = patt.ip_address:match(msg.Payload)
+        if m then
+            msg.Fields.http_client_ip_address = m.ip_address
+        end
+    end
+
+    return utils.safe_inject_message(msg)
+end

--- a/results/files/heka/lua_decoders/os_rabbitmq_log.lua
+++ b/results/files/heka/lua_decoders/os_rabbitmq_log.lua
@@ -1,0 +1,79 @@
+-- Copyright 2015-2016 Mirantis, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+local dt     = require "date_time"
+local l      = require 'lpeg'
+l.locale(l)
+
+local patt   = require 'os_patterns'
+local utils  = require 'os_utils'
+
+
+-- Allow custom type
+t = read_config('type')
+if t == nil or t == '' then
+  t = 'log'
+end
+
+local msg = {
+    Timestamp   = nil,
+    Type        = t,
+    Hostname    = nil,
+    Payload     = nil,
+    Pid         = nil,
+    Fields      = nil,
+    Severity    = nil,
+}
+
+-- RabbitMQ message logs are formatted like this:
+--   =ERROR REPORT==== 2-Jan-2015::09:17:22 ===
+--   Blabla
+--   Blabla
+--
+local message   = l.Cg(patt.Message / utils.chomp, "Message")
+-- The token before 'REPORT' isn't standardized so it can be a valid severity
+-- level as 'INFO' or 'ERROR' but also 'CRASH' or 'SUPERVISOR'.
+local severity  = l.Cg(l.R"AZ"^1, "SeverityLabel")
+local day = l.R"13" * l.R"09" + l.R"19"
+local datetime = l.Cg(day, "day") * patt.dash * dt.date_mabbr * patt.dash * dt.date_fullyear *
+                 "::" * dt.rfc3339_partial_time
+local timestamp = l.Cg(l.Ct(datetime)/ dt.time_to_ns, "Timestamp")
+
+local grammar = l.Ct("=" * severity * " REPORT==== " * timestamp * " ===" * l.P'\n' * message)
+
+function process_message ()
+    local log = read_message("Payload")
+
+    local m = grammar:match(log)
+    if not m then
+        return -1
+    end
+
+    msg.Timestamp = m.Timestamp
+    msg.Payload = m.Message
+    msg.Logger = read_message("Logger")
+
+    if utils.label_to_severity_map[m.SeverityLabel] then
+        msg.Severity = utils.label_to_severity_map[m.SeverityLabel]
+    elseif m.SeverityLabel == 'CRASH' then
+        msg.Severity = 2 -- CRITICAL
+    else
+        msg.Severity = 5 -- NOTICE
+    end
+
+    msg.Fields = {}
+    msg.Fields.severity_label = utils.severity_to_label_map[msg.Severity]
+    msg.Fields.programname = 'rabbitmq'
+
+    return utils.safe_inject_message(msg)
+end

--- a/results/files/kibana/all_objects.json
+++ b/results/files/kibana/all_objects.json
@@ -1,0 +1,81 @@
+[
+  {
+    "_id": "Logs",
+    "_type": "dashboard",
+    "_source": {
+      "title": "Logs",
+      "hits": 0,
+      "description": "",
+      "panelsJSON": "[{\"id\":\"Types\",\"type\":\"visualization\",\"panelIndex\":1,\"size_x\":4,\"size_y\":3,\"col\":1,\"row\":1},{\"id\":\"progname\",\"type\":\"visualization\",\"panelIndex\":2,\"size_x\":4,\"size_y\":3,\"col\":5,\"row\":1},{\"id\":\"http_status\",\"type\":\"visualization\",\"panelIndex\":3,\"size_x\":4,\"size_y\":3,\"col\":9,\"row\":1},{\"id\":\"raw\",\"type\":\"search\",\"panelIndex\":4,\"size_x\":12,\"size_y\":6,\"col\":1,\"row\":4,\"columns\":[\"_source\"],\"sort\":[\"Timestamp\",\"desc\"]}]",
+      "optionsJSON": "{\"darkTheme\":false}",
+      "uiStateJSON": "{}",
+      "version": 1,
+      "timeRestore": false,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}]}"
+      }
+    }
+  },
+  {
+    "_id": "raw",
+    "_type": "search",
+    "_source": {
+      "title": "raw",
+      "description": "",
+      "hits": 0,
+      "columns": [
+        "_source"
+      ],
+      "sort": [
+        "Timestamp",
+        "desc"
+      ],
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"heka*\",\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}"
+      }
+    }
+  },
+  {
+    "_id": "progname",
+    "_type": "visualization",
+    "_source": {
+      "title": "progname",
+      "visState": "{\"title\":\"progname\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"programname\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"heka*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+      }
+    }
+  },
+  {
+    "_id": "http_status",
+    "_type": "visualization",
+    "_source": {
+      "title": "http_status",
+      "visState": "{\"title\":\"http_status\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"http_status\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"heka*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+      }
+    }
+  },
+  {
+    "_id": "Types",
+    "_type": "visualization",
+    "_source": {
+      "title": "Types",
+      "visState": "{\"title\":\"Types\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"Type\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"heka*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+      }
+    }
+  }
+]

--- a/results/templates/heka-elasticsearch.toml.j2
+++ b/results/templates/heka-elasticsearch.toml.j2
@@ -1,0 +1,18 @@
+[elasticsearch_json_encoder]
+type = "ESJsonEncoder"
+#index = "{{ item }}"
+index = "heka"
+es_index_from_timestamp = true
+fields = ["Timestamp", "Type", "Logger", "Severity", "Payload", "Pid", "Hostname", "DynamicFields"]
+
+[elasticsearch_output]
+type = "ElasticSearchOutput"
+# elastic container is likned to heka one
+server = "http://elasticsearch:9200"
+message_matcher = "Type =~ /^log.*/"
+encoder = "elasticsearch_json_encoder"
+use_buffering = true
+    [elasticsearch_output.buffering]
+    max_buffer_size = 1073741824  # 1024 * 1024 * 1024
+    max_file_size = 134217728  # 128 * 1024 * 1024
+    full_action = "drop"

--- a/results/templates/heka-keystone.toml.j2
+++ b/results/templates/heka-keystone.toml.j2
@@ -1,0 +1,14 @@
+[keystone_apache_log_decoder]
+type = "SandboxDecoder"
+filename = "lua_decoders/os_keystone_apache_log.lua"
+    [keystone_apache_log_decoder.config]
+    type = "log-{{ item[1] }}"
+    apache_log_pattern = '%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b %D \"%{Referer}i\" \"%{User-Agent}i\"'
+
+[keystone_apache_logstreamer_input]
+type = "LogstreamerInput"
+decoder = "keystone_apache_log_decoder"
+log_directory = "/var/log/kolla"
+file_match = 'keystone/keystone-apache-(?P<Service>.+)-access\.log\.?(?P<Seq>\d*)$'
+priority = ["^Seq"]
+differentiator = ["keystone-apache-", "Service"]

--- a/results/templates/heka-mariadb.toml.j2
+++ b/results/templates/heka-mariadb.toml.j2
@@ -1,0 +1,14 @@
+[mariadb_log_decoder]
+type = "SandboxDecoder"
+filename = "lua_decoders/os_mysql_log.lua"
+
+[mariadb_log_decoder.config]
+type = "log-{{ item[1] }}"
+
+[mariadb_logstreamer_input]
+type = "LogstreamerInput"
+decoder = "mariadb_log_decoder"
+log_directory = "/var/log/kolla"
+file_match = 'mariadb/mariadb\.log\.?(?P<Seq>\d*)$'
+priority = ["^Seq"]
+differentiator = ['mariadb']

--- a/results/templates/heka-openstack.toml.j2
+++ b/results/templates/heka-openstack.toml.j2
@@ -1,0 +1,15 @@
+[openstack_log_decoder]
+type = "SandboxDecoder"
+filename = "lua_decoders/os_openstack_log.lua"
+
+[openstack_log_decoder.config]
+type = "log-{{ item[1] }}"
+
+[openstack_logstreamer_input]
+type = "LogstreamerInput"
+decoder = "openstack_log_decoder"
+log_directory = "/var/log/kolla"
+file_match = '(?P<Service>cloudkitty|nova|glance|keystone|neutron|ceph|cinder|heat|murano|magnum|mistral|manila|senlin)/(?P<Program>.*)\.log\.?(?P<Seq>\d*)$'
+priority = ["^Seq"]
+differentiator = ["Service", "_", "Program"]
+

--- a/results/templates/heka-rabbitmq.toml.j2
+++ b/results/templates/heka-rabbitmq.toml.j2
@@ -1,0 +1,21 @@
+[rabbitmq_log_decoder]
+type = "SandboxDecoder"
+filename = "lua_decoders/os_rabbitmq_log.lua"
+
+[rabbitmq_log_decoder.config]
+type = "log-{{ item[1] }}"
+
+[rabbitmq_log_splitter]
+type = "RegexSplitter"
+delimiter = '\n\n(=[^=]+====)'
+delimiter_eol = false
+deliver_incomplete_final = true
+
+[rabbitmq_logstreamer_input]
+type = "LogstreamerInput"
+decoder = "rabbitmq_log_decoder"
+splitter = "rabbitmq_log_splitter"
+log_directory = "/var/log/kolla"
+file_match = 'rabbitmq/(?P<Service>rabbit.*)\.log\.?(?P<Seq>\d*)$'
+priority = ["^Seq"]
+differentiator = ["Service"]


### PR DESCRIPTION
Logs aren't indexed during the run of an experiment.
This commit is about indexing all the logs in the post-mortem phase.
To do so I reuse the heka docker image from kolla and all the files
allowing the pipeline between the log and elasticsearch to work.

In comparision to the original decoders we allow the customization of
the Type field to differentiate logs from different experiments.
Note that the indexation process may take some time !

M
