### PR TITLE
Single eth, Cinder and disk

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -31,3 +31,7 @@ patches:
     src: haproxy.cfg.j2
     dst: kolla/ansible/roles/haproxy/templates/haproxy.cfg.j2
     enabled: "no"
+  - name: patch site.yml
+    src: site.yml
+    dst: kolla/ansible/site.yml
+    enabled: "no"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -5,6 +5,7 @@ g5k_role: unknown
 
 enable_monitoring: true
 enable_rally: true
+enable_nova_tmp: false
 
 # will be copied on the rally host to launch scenarios
 rally_scenarios_dir: "{{ playbook_dir }}/../rally/"

--- a/ansible/prepare-node.yml
+++ b/ansible/prepare-node.yml
@@ -56,3 +56,10 @@
     - { role: rally,
         tags: ['rally'],
         when: enable_rally | bool }
+
+- name: Bind /var/lib/nova to /tmp
+  hosts: compute
+  roles:
+    - { role: nova,
+        tags: ['nova-tmp'],
+        when: enable_nova_tmp | bool }

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- include: single_interface.yml
+  when: "{{ enable_veth | bool }}"
+
 - name: Adding Docker apt key
   apt_key: keyserver=hkp://p80.pool.sks-keyservers.net:80 id=58118E89F3A912897C070ADBF76221572C52609D
 

--- a/ansible/roles/common/tasks/single_interface.yml
+++ b/ansible/roles/common/tasks/single_interface.yml
@@ -1,0 +1,27 @@
+---
+#- name: Installing bridge-utils
+#  apt: name=bridge-utils state=present
+
+- name: Creating virtual interface veth0
+  shell: ip link show veth0 || ip link add type veth peer
+
+#- name: Creating a bridge
+#  shell: brctl show | grep br0 || brctl addbr br0
+#
+#- name:  Setting IP {{ neutron_external_address }} for veth0
+#  shell: ip addr show | grep {{ neutron_external_address }} || ip addr add {{ neutron_external_address }} dev veth0
+#
+#- name: Turning veth0 up
+#  shell: ip link set veth0 up
+#
+#- name: Turning veth1 up
+#  shell: ip link set veth1 up
+#
+#- name: Connecting veth1 to br0
+#  shell: brctl addif br0 eth0
+#
+#- name: Connecting eth0 to br0
+#  shell: brctl addif br0 veth1
+#
+#- name: Turning br0 up
+#  shell: ifconfig br0 up

--- a/ansible/roles/nova/tasks/main.yml
+++ b/ansible/roles/nova/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Create /var/lib/docker/volumes
+  file: path=/var/lib/docker/volumes state=directory owner=65500
+
+- name: Create /tmp/docker/volumes
+  file: path=/tmp/docker/volumes state=directory owner=65500
+    
+- name: Bind /var/lib/docker/volumes to /tmp/docker/volumes
+  mount:
+    name: /var/lib/docker/volumes
+    src: /tmp/docker/volumes
+    opts: rw,bind
+    fstype: ext4
+    state: mounted
+
+- name: Create /var/lib/nova
+  file: path=/var/lib/nova state=directory owner=65500
+
+- name: Create /tmp/nova
+  file: path=/tmp/nova state=directory owner=65500
+
+- name: Bind /var/lib/nova to /tmp/nova
+  mount:
+    name: /var/lib/nova
+    src: /tmp/nova
+    opts: rw,bind
+    fstype: ext4
+    state: mounted

--- a/ansible/roles/patches/files/site.yml
+++ b/ansible/roles/patches/files/site.yml
@@ -1,0 +1,211 @@
+---
+- hosts:
+    - ceph-mon
+    - ceph-osd
+    - ceph-rgw
+  roles:
+    - { role: ceph,
+        tags: ceph,
+        when: enable_ceph | bool }
+
+- hosts: elasticsearch
+  roles:
+    - { role: elasticsearch,
+        tags: elasticsearch,
+        when: enable_central_logging | bool }
+
+- hosts:
+    - cinder-api
+    - glance-api
+    - haproxy
+    - keystone
+    - mariadb
+    - murano-api
+    - neutron-server
+    - nova-api
+    - rabbitmq
+    - swift-proxy-server
+    - heat-api
+    - murano-api
+  roles:
+    - { role: haproxy,
+        tags: haproxy,
+        when: enable_haproxy | bool }
+
+- hosts: kibana
+  roles:
+    - { role: kibana,
+        tags: kibana,
+        when: enable_central_logging | bool }
+
+- hosts: memcached
+  roles:
+    - { role: memcached,
+        tags: [memcache, memcached],
+        when: enable_memcached | bool }
+
+- hosts: mariadb
+  roles:
+    - { role: mariadb,
+        tags: mariadb,
+        when: enable_mariadb | bool }
+
+- hosts: rabbitmq
+  roles:
+    - { role: rabbitmq,
+        tags: rabbitmq,
+        when: enable_rabbitmq | bool }
+
+- hosts:
+    - keystone
+    - memcached
+  roles:
+    - { role: keystone,
+        tags: keystone,
+        when: enable_keystone | bool }
+
+- hosts:
+    - swift-account-server
+    - swift-container-server
+    - swift-object-server
+    - swift-proxy-server
+    - rabbitmq
+    - memcached
+  roles:
+    - { role: swift,
+        tags: swift,
+        when: enable_swift | bool }
+
+- hosts:
+    - glance-api
+    - ceph-mon
+    - glance-registry
+    - rabbitmq
+    - memcached
+  roles:
+    - { role: glance,
+        tags: glance,
+        when: enable_glance | bool }
+
+- hosts:
+    - ceph-mon
+    - compute
+    - glance-api
+    - nova-api
+    - nova-conductor
+    - nova-consoleauth
+    - nova-novncproxy
+    - nova-scheduler
+    - rabbitmq
+    - memcached
+  roles:
+    - { role: nova,
+        tags: nova,
+        when: enable_nova | bool }
+
+- hosts:
+    - neutron-server
+    - neutron-dhcp-agent
+    - neutron-l3-agent
+    - neutron-metadata-agent
+    - compute
+    - manila-share
+    - rabbitmq
+    - memcached
+  roles:
+    - { role: neutron,
+        tags: neutron,
+        when: enable_neutron | bool }
+
+- hosts:
+    - cinder-api
+    - ceph-mon
+    - cinder-backup
+    - cinder-scheduler
+    - cinder-volume
+    - rabbitmq
+    - memcached
+  roles:
+    - { role: cinder,
+        tags: cinder,
+        when: enable_cinder | bool }
+
+- hosts:
+    - heat-api
+    - heat-api-cfn
+    - heat-engine
+    - rabbitmq
+    - memcached
+  roles:
+    - { role: heat,
+        tags: heat,
+        when: enable_heat | bool }
+
+- hosts:
+    - horizon
+    - memcached
+  roles:
+    - { role: horizon,
+        tags: horizon,
+        when: enable_horizon | bool }
+
+- hosts:
+    - murano-api
+    - murano-engine
+    - rabbitmq
+    - memcached
+  roles:
+    - { role: murano,
+        tags: murano,
+        when: enable_murano | bool }
+
+- hosts:
+    - ironic-api
+    - ironic-conductor
+    - ironic-inspector
+    - ironic-pxe
+    - rabbitmq
+    - memcached
+  roles:
+    - { role: ironic,
+        tags: ironic,
+        when: enable_ironic | bool }
+
+- hosts:
+    - magnum-api
+    - magnum-conductor
+    - rabbitmq
+    - memcached
+  roles:
+    - { role: magnum,
+        tags: magnum,
+        when: enable_magnum | bool }
+
+- hosts:
+    - mistral-api
+    - mistral-engine
+    - mistral-executor
+    - rabbitmq
+    - memcached
+  roles:
+    - { role: mistral,
+        tags: mistral,
+        when: enable_mistral | bool }
+
+- hosts:
+    - mongodb
+  roles:
+    - { role: mongodb,
+        tags: mongodb,
+        when: enable_mongodb | bool }
+
+- hosts:
+    - manila-api
+    - manila-share
+    - manila-scheduler
+    - rabbitmq
+    - memcached
+  roles:
+    - { role: manila,
+        tags: manila,
+        when: enable_manila | bool }

--- a/engine/g5k_engine.py
+++ b/engine/g5k_engine.py
@@ -109,6 +109,10 @@ class G5kEngine(Engine):
             self._make_reservation()
         else:
             logger.info("Using running oargrid job %s" % style.emph(self.gridjob))
+            
+
+        # Wait for the job to start
+        EX5.wait_oargrid_job_start(self.gridjob)
 
         attempts = 0
         self.nodes = None

--- a/reservation.yaml.sample
+++ b/reservation.yaml.sample
@@ -24,6 +24,10 @@ role_distribution: debug
 #enable_monitoring: true
 #enable_rally: true
 
+# Enable for Nova to run in /tmp, allowing larger flavors
+# to be deployed
+enable_nova_tmp: false
+
 # ############################################### #
 # Inventory to use                                #
 # ############################################### #


### PR DESCRIPTION
3 big fixes, and a small one
− allows Kolla to deploy on a single nodes with a single interface
− allows to deploy larger flavors
− allows to deploy Cinder and Glance on dedicated nodes
− the engine now correctly waits for the g5k job to start
